### PR TITLE
📚 Fix README.md CSV documentation - Fixes #3

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,22 @@ pyforge convert data.dbf
 pyforge convert database.accdb output_folder/
 ```
 
+### Convert CSV Files
+
+```bash
+# Convert CSV with automatic delimiter and encoding detection
+pyforge convert data.csv
+
+# Convert TSV (tab-separated) file
+pyforge convert data.tsv
+
+# Convert with compression
+pyforge convert sales_data.csv --compression gzip
+
+# Convert delimited text file
+pyforge convert export.txt
+```
+
 ### Get File Information
 
 ```bash
@@ -204,6 +220,25 @@ pyforge convert legacy.dbf --encoding cp1252
 for file in *.dbf; do pyforge convert "$file"; done
 ```
 
+### CSV Conversion Examples
+
+```bash
+# Convert CSV with automatic detection
+pyforge convert sales_data.csv
+
+# Convert international CSV with auto-encoding detection
+pyforge convert european_data.csv --verbose
+
+# Convert semicolon-delimited CSV (European format)
+pyforge convert data_semicolon.csv
+
+# Convert tab-separated file with compression
+pyforge convert data.tsv --compression gzip
+
+# Batch convert multiple CSV files
+for file in *.csv; do pyforge convert "$file" --compression snappy; done
+```
+
 ### File Information
 
 ```bash
@@ -228,7 +263,7 @@ pyforge info document.pdf --format json > metadata.json
 | Excel (.xlsx) | Parquet (.parquet) | ✅ Available |
 | Access (.mdb/.accdb) | Parquet (.parquet) | ✅ Available |
 | DBF (.dbf)  | Parquet (.parquet) | ✅ Available |
-| CSV (.csv)  | Parquet (.parquet) | 🚧 Coming Soon |
+| CSV (.csv, .tsv, .txt) | Parquet (.parquet) | ✅ Available |
 
 ## Development
 
@@ -339,7 +374,8 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
   - Robust error handling for corrupted files
 
 ### Version 0.3.0 - Enhanced Features (Planned)
-- [ ] CSV to Parquet conversion with schema inference
+- [x] CSV to Parquet conversion with auto-detection (string-based)
+- [ ] CSV schema inference and native type conversion
 - [ ] JSON processing and flattening
 - [ ] Data validation and cleaning options
 - [ ] Batch processing with pattern matching


### PR DESCRIPTION
## 📋 Summary
Fixes the outdated documentation in README.md where CSV to Parquet conversion was listed as "🚧 Coming Soon" instead of "✅ Available". This addresses issue #3 which identified a documentation gap after the CSV converter was implemented in PR #2.

## 🐛 Bug Fixed
- **Issue**: README.md supported formats table showed CSV as "Coming Soon"
- **Root Cause**: Documentation not updated when CSV converter was implemented
- **Impact**: Users unaware of CSV conversion capabilities when visiting repository

## ✅ Changes Made

### 📊 Supported Formats Table
- **Before**: `| CSV (.csv) | Parquet (.parquet) | 🚧 Coming Soon |`
- **After**: `| CSV (.csv, .tsv, .txt) | Parquet (.parquet) | ✅ Available |`

### 📝 Documentation Additions
1. **Basic Usage Section**: Added "Convert CSV Files" with auto-detection examples
2. **Detailed Examples Section**: Added "CSV Conversion Examples" with comprehensive scenarios
3. **Roadmap Update**: Marked CSV auto-detection as completed, added future schema inference

### 🔄 Type of Change
- ✅ Bug fix (documentation correction)
- ✅ Documentation enhancement
- ✅ Feature visibility improvement

## 📚 New Documentation Content

### Basic CSV Examples Added:
```bash
# Convert CSV with automatic delimiter and encoding detection
pyforge convert data.csv

# Convert TSV (tab-separated) file
pyforge convert data.tsv

# Convert with compression
pyforge convert sales_data.csv --compression gzip

# Convert delimited text file
pyforge convert export.txt
```

### Advanced CSV Examples Added:
```bash
# Convert international CSV with auto-encoding detection
pyforge convert european_data.csv --verbose

# Convert semicolon-delimited CSV (European format)  
pyforge convert data_semicolon.csv

# Batch convert multiple CSV files
for file in *.csv; do pyforge convert "$file" --compression snappy; done
```

## 🔍 Validation Performed
- ✅ **Accuracy Check**: Verified information matches actual CSV converter capabilities
- ✅ **Format Consistency**: Maintained existing README structure and style
- ✅ **Link Validation**: Ensured markdown formatting renders correctly
- ✅ **Completeness**: Updated all relevant sections (table, examples, roadmap)

## 📊 Before vs After

### Supported Formats Table
**Before**:
```markdown
| CSV (.csv)  | Parquet (.parquet) | 🚧 Coming Soon |
```

**After**:
```markdown
| CSV (.csv, .tsv, .txt) | Parquet (.parquet) | ✅ Available |
```

### Examples Coverage
**Before**: No CSV examples in README
**After**: Complete CSV examples in both basic and advanced sections

### Roadmap Status
**Before**: 
```markdown
- [ ] CSV to Parquet conversion with schema inference
```

**After**:
```markdown
- [x] CSV to Parquet conversion with auto-detection (string-based)
- [ ] CSV schema inference and native type conversion
```

## 🎯 Impact
- ✅ **User Discovery**: Users visiting GitHub can now see CSV conversion is available
- ✅ **Feature Adoption**: Clear examples help users understand CSV capabilities
- ✅ **Documentation Accuracy**: README now matches actual implementation
- ✅ **Project Credibility**: Complete and up-to-date feature documentation

## 🔗 Related Work
- **Fixes**: Issue #3 (README.md missing CSV converter documentation)
- **Related**: PR #2 (CSV converter implementation)
- **Follows**: CSV converter supports .csv, .tsv, .txt with auto-detection

## 📋 Reviewer Checklist
- ✅ Documentation accurately reflects CSV converter capabilities
- ✅ Examples are practical and demonstrate key features
- ✅ Markdown formatting is correct and renders properly
- ✅ No breaking changes to existing documentation structure
- ✅ All references to CSV feature status are consistent

## 🚀 Ready for Merge
This is a straightforward documentation fix that aligns README.md with the actual implemented features. No code changes, just essential documentation updates to ensure users are aware of available capabilities.

---
**Fix Summary**: Updated README.md to accurately reflect that CSV to Parquet conversion is now available with auto-detection features, added comprehensive examples, and corrected the roadmap status.