### PR TITLE
Documentation audit: Update help system and docs for XML converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,11 @@
 
 - **PDF to Text Conversion**: Extract text from PDF documents with advanced options
 - **Excel to Parquet Conversion**: Convert Excel files (.xlsx) to Parquet format with multi-sheet support
+- **XML to Parquet Conversion**: Intelligent XML flattening with automatic structure detection and configurable strategies
 - **Database File Conversion**: Convert Microsoft Access (.mdb/.accdb) and DBF files to Parquet
+- **CSV to Parquet Conversion**: Smart delimiter detection and encoding handling
 - **Rich CLI Interface**: Beautiful terminal output with progress bars and tables
-- **Intelligent Processing**: Automatic encoding detection, table discovery, and column matching
+- **Intelligent Processing**: Automatic encoding detection, structure analysis, and column matching
 - **Extensible Architecture**: Plugin-based system for adding new format converters
 - **Metadata Extraction**: Get detailed information about your files
 - **Cross-platform**: Works on Windows, macOS, and Linux
@@ -132,6 +134,25 @@ pyforge convert sales_data.csv --compression gzip
 
 # Convert delimited text file
 pyforge convert export.txt
+```
+
+### Convert XML Files
+
+```bash
+# Convert XML with automatic structure detection
+pyforge convert data.xml
+
+# Convert with aggressive flattening for analytics
+pyforge convert catalog.xml --flatten-strategy aggressive
+
+# Handle arrays by expanding to multiple rows
+pyforge convert orders.xml --array-handling expand
+
+# Strip namespaces for cleaner column names
+pyforge convert api_response.xml --namespace-handling strip
+
+# Preview schema before conversion
+pyforge convert complex.xml --preview-schema
 ```
 
 ### Get File Information
@@ -245,6 +266,31 @@ pyforge convert data.tsv --compression gzip
 for file in *.csv; do pyforge convert "$file" --compression snappy; done
 ```
 
+### XML Conversion Examples
+
+```bash
+# Convert XML with automatic structure detection
+pyforge convert catalog.xml
+
+# Convert with aggressive flattening for data analysis
+pyforge convert api_response.xml --flatten-strategy aggressive
+
+# Handle arrays as concatenated strings
+pyforge convert orders.xml --array-handling concatenate
+
+# Strip namespaces for cleaner output
+pyforge convert soap_response.xml --namespace-handling strip
+
+# Preview structure before conversion
+pyforge convert complex_structure.xml --preview-schema
+
+# Convert compressed XML files
+pyforge convert data.xml.gz --verbose
+
+# Batch convert XML files with specific strategy
+for file in *.xml; do pyforge convert "$file" --flatten-strategy moderate; done
+```
+
 ### File Information
 
 ```bash
@@ -267,6 +313,7 @@ pyforge info document.pdf --format json > metadata.json
 |-------------|----------------|---------|
 | PDF (.pdf)  | Text (.txt)    | ✅ Available |
 | Excel (.xlsx) | Parquet (.parquet) | ✅ Available |
+| XML (.xml, .xml.gz, .xml.bz2) | Parquet (.parquet) | ✅ Available |
 | Access (.mdb/.accdb) | Parquet (.parquet) | ✅ Available |
 | DBF (.dbf)  | Parquet (.parquet) | ✅ Available |
 | CSV (.csv, .tsv, .txt) | Parquet (.parquet) | ✅ Available |
@@ -379,8 +426,15 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
   - Support for various DBF formats
   - Robust error handling for corrupted files
 
-### Version 0.3.0 - Enhanced Features (Planned)
-- [x] CSV to Parquet conversion with auto-detection (string-based)
+### Version 0.3.0 - Enhanced Features (Released)
+- ✅ **XML to Parquet Conversion**
+  - Automatic XML structure detection and analysis
+  - Intelligent flattening strategies (conservative, moderate, aggressive)
+  - Array handling modes (expand, concatenate, json_string)
+  - Namespace processing (preserve, strip, prefix)
+  - Schema preview before conversion
+  - Support for compressed XML files (.xml.gz, .xml.bz2)
+- ✅ **CSV to Parquet conversion** with auto-detection (string-based)
 - [ ] CSV schema inference and native type conversion
 - [ ] JSON processing and flattening
 - [ ] Data validation and cleaning options
@@ -407,7 +461,18 @@ If you encounter any issues or have questions:
 
 ## Changelog
 
-### 0.2.1 (Current Release)
+### 0.3.0 (Current Release)
+
+- ✅ **XML to Parquet Converter**: Complete implementation with intelligent flattening
+- ✅ **Automatic Structure Detection**: Analyzes XML hierarchy and array patterns
+- ✅ **Flexible Flattening Strategies**: Conservative, moderate, and aggressive options
+- ✅ **Advanced Array Handling**: Expand, concatenate, or JSON string modes
+- ✅ **Namespace Support**: Configurable namespace processing
+- ✅ **Schema Preview**: Optional structure preview before conversion
+- ✅ **Comprehensive Documentation**: User guide and quick reference
+- ✅ **Compressed XML Support**: Handles .xml.gz and .xml.bz2 files
+
+### 0.2.1
 
 - ✅ **Complete Documentation Site**: Comprehensive GitHub Pages documentation
 - ✅ **Fixed CI/CD**: GitHub Actions workflow for automated PyPI publishing  

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -23,6 +23,12 @@ cortexpy formats
 # Convert a PDF to text
 cortexpy convert document.pdf
 
+# Convert XML to Parquet with intelligent flattening
+cortexpy convert api_response.xml --flatten-strategy aggressive
+
+# Convert Excel to Parquet
+cortexpy convert spreadsheet.xlsx --format parquet
+
 # Get file information
 cortexpy info document.pdf
 

--- a/docs/converters/index.md
+++ b/docs/converters/index.md
@@ -42,6 +42,22 @@ PyForge CLI supports conversion between multiple data formats. Each converter is
 
     [:octicons-arrow-right-24: Learn More](dbf-files.md)
 
+-   :material-code-xml: **XML to Parquet**
+
+    ---
+
+    Convert XML files to Parquet with intelligent flattening
+
+    [:octicons-arrow-right-24: Learn More](../xml-converter.md)
+
+-   :material-file-delimited: **CSV to Parquet**
+
+    ---
+
+    Convert CSV/TSV files to Parquet with auto-detection
+
+    [:octicons-arrow-right-24: Learn More](csv-to-parquet.md)
+
 </div>
 
 ## Format Compatibility Matrix
@@ -50,9 +66,10 @@ PyForge CLI supports conversion between multiple data formats. Each converter is
 |-------------|-----------------|---------------|--------|-------------------|
 | **PDF** | `.pdf` | Text (`.txt`) | ✅ Stable | Windows, macOS, Linux |
 | **Excel** | `.xlsx` | Parquet (`.parquet`) | ✅ Stable | Windows, macOS, Linux |
+| **XML** | `.xml`, `.xml.gz`, `.xml.bz2` | Parquet (`.parquet`) | ✅ Stable | Windows, macOS, Linux |
 | **Access** | `.mdb`, `.accdb` | Parquet (`.parquet`) | ✅ Stable | Windows, macOS*, Linux* |
 | **DBF** | `.dbf` | Parquet (`.parquet`) | ✅ Stable | Windows, macOS, Linux |
-| **CSV** | `.csv` | Parquet (`.parquet`) | 🚧 Coming Soon | Windows, macOS, Linux |
+| **CSV** | `.csv`, `.tsv`, `.txt` | Parquet (`.parquet`) | ✅ Stable | Windows, macOS, Linux |
 
 *Requires mdbtools installation
 
@@ -115,6 +132,12 @@ pyforge convert database.mdb
 
 # Convert DBF file
 pyforge convert legacy.dbf
+
+# Convert XML with intelligent flattening
+pyforge convert api_response.xml
+
+# Convert CSV with auto-detection
+pyforge convert data.csv
 ```
 
 ### Advanced Options
@@ -131,6 +154,12 @@ pyforge convert database.mdb output_directory/
 
 # DBF with specific encoding
 pyforge convert legacy.dbf --encoding cp1252
+
+# XML with aggressive flattening and array expansion
+pyforge convert catalog.xml --flatten-strategy aggressive --array-handling expand
+
+# CSV with compression
+pyforge convert large_data.csv --compression gzip
 ```
 
 ## Performance Considerations
@@ -141,8 +170,10 @@ pyforge convert legacy.dbf --encoding cp1252
 |--------|-------|--------|-------|------------|
 | **PDF** | < 10 MB | 10-100 MB | 100 MB - 1 GB | > 1 GB |
 | **Excel** | < 50 MB | 50-200 MB | 200 MB - 1 GB | > 1 GB |
+| **XML** | < 10 MB | 10-100 MB | 100 MB - 1 GB | > 1 GB |
 | **Access** | < 100 MB | 100 MB - 1 GB | 1-10 GB | > 10 GB |
 | **DBF** | < 50 MB | 50-500 MB | 500 MB - 2 GB | > 2 GB |
+| **CSV** | < 50 MB | 50-500 MB | 500 MB - 2 GB | > 2 GB |
 
 ### Optimization Tips
 
@@ -210,8 +241,10 @@ Choose a converter to learn more about:
 
 - **[PDF to Text](pdf-to-text.md)** - Document processing and text extraction
 - **[Excel to Parquet](excel-to-parquet.md)** - Spreadsheet data conversion
+- **[XML to Parquet](../xml-converter.md)** - XML flattening and structure analysis
 - **[Database Files](database-files.md)** - Access database migration
 - **[DBF Files](dbf-files.md)** - Legacy database modernization
+- **[CSV to Parquet](csv-to-parquet.md)** - Delimited file processing
 
 Or explore other sections:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,6 +61,9 @@ pyforge convert spreadsheet.xlsx
 # Convert Access database
 pyforge convert database.mdb
 
+# Convert XML with intelligent flattening
+pyforge convert api_response.xml
+
 # Get help
 pyforge --help
 ```
@@ -71,6 +74,7 @@ pyforge --help
 |-------------|---------------|--------|-------------|
 | **PDF** (.pdf) | Text (.txt) | ✅ Available | Extract text with metadata and page ranges |
 | **Excel** (.xlsx) | Parquet (.parquet) | ✅ Available | Multi-sheet support with intelligent merging |
+| **XML** (.xml, .xml.gz, .xml.bz2) | Parquet (.parquet) | ✅ Available | Intelligent flattening with configurable strategies |
 | **Access** (.mdb/.accdb) | Parquet (.parquet) | ✅ Available | Cross-platform database conversion |
 | **DBF** (.dbf) | Parquet (.parquet) | ✅ Available | Legacy database with encoding detection |
 | **CSV** (.csv) | Parquet (.parquet) | ✅ Available | Auto-detection of delimiters and encoding |
@@ -116,6 +120,14 @@ Designed specifically for data engineers, scientists, and analysts with real-wor
     
     ```bash
     pyforge convert financial_report.xlsx --combine --compression gzip
+    ```
+
+!!! example "XML API Data Processing"
+    Convert XML API responses and configuration files to Parquet for data analysis.
+    
+    ```bash
+    pyforge convert api_response.xml --flatten-strategy aggressive --array-handling expand
+    pyforge convert config.xml --namespace-handling strip
     ```
 
 ## Getting Started
@@ -167,7 +179,17 @@ Choose your path based on your experience level:
 
 ## What's New
 
-### Version 0.2.5 (Latest)
+### Version 0.3.0 (Latest)
+- ✅ **XML to Parquet Converter**: Complete implementation with intelligent flattening
+- ✅ **Automatic Structure Detection**: Analyzes XML hierarchy and array patterns
+- ✅ **Flexible Flattening Strategies**: Conservative, moderate, and aggressive options
+- ✅ **Advanced Array Handling**: Expand, concatenate, or JSON string modes
+- ✅ **Namespace Support**: Configurable namespace processing
+- ✅ **Schema Preview**: Optional structure preview before conversion
+- ✅ **Comprehensive Documentation**: User guide and quick reference
+- ✅ **Compressed XML Support**: Handles .xml.gz and .xml.bz2 files
+
+### Version 0.2.5
 - ✅ Fixed package build configuration and PyPI publication metadata
 - ✅ Resolved InvalidDistribution errors for wheel packaging
 - ✅ Updated hatchling build configuration for src layout

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -27,8 +27,14 @@ pyforge convert report.pdf --pages "1-10"
 # Excel with specific sheets
 pyforge convert data.xlsx --sheets "Sheet1,Summary"
 
+# XML with intelligent flattening
+pyforge convert api_response.xml --flatten-strategy aggressive
+
 # Database conversion
 pyforge convert database.mdb output_directory/
+
+# CSV with auto-detection
+pyforge convert data.csv --compression gzip
 ```
 
 #### Options
@@ -45,6 +51,10 @@ pyforge convert database.mdb output_directory/
 | `--encoding <encoding>` | string | Character encoding (e.g., cp1252) | DBF |
 | `--tables <names>` | string | Comma-separated table names | MDB/ACCDB |
 | `--password <password>` | string | Database password | MDB/ACCDB |
+| `--flatten-strategy <strategy>` | string | XML flattening: conservative, moderate, aggressive | XML |
+| `--array-handling <mode>` | string | XML array handling: expand, concatenate, json_string | XML |
+| `--namespace-handling <mode>` | string | XML namespace handling: preserve, strip, prefix | XML |
+| `--preview-schema` | flag | Preview XML structure before conversion | XML |
 | `--force` | flag | Overwrite existing output files | All |
 | `--verbose` | flag | Enable detailed output | All |
 

--- a/docs/reference/output-formats.md
+++ b/docs/reference/output-formats.md
@@ -16,9 +16,11 @@ Detailed output format specifications will be available in a future release.
 - **Features**: Preserves line breaks and basic formatting
 
 ### Parquet (.parquet)
-- **Used for**: Excel, MDB/ACCDB, DBF conversion
+- **Used for**: Excel, XML, MDB/ACCDB, DBF, CSV conversion
 - **Compression**: SNAPPY (default), GZIP, LZ4, ZSTD
 - **Features**: Column-oriented, highly compressed, fast read/write
+- **Data Types**: String-based conversion (Phase 1 implementation)
+- **Schemas**: Automatically inferred from source structure
 
 ## Format Details
 
@@ -26,8 +28,10 @@ For detailed information about each output format, see:
 
 - [PDF to Text Converter](../converters/pdf-to-text.md)
 - [Excel to Parquet Converter](../converters/excel-to-parquet.md)
+- [XML to Parquet Converter](../xml-converter.md)
 - [Database Files Converter](../converters/database-files.md)
 - [DBF Files Converter](../converters/dbf-files.md)
+- [CSV to Parquet Converter](../converters/csv-to-parquet.md)
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary
Completes comprehensive documentation audit to update all help text and documentation for the XML converter capabilities added in v0.3.0.

## Changes Made

### CLI Help System Updates
- ✅ **Main Help**: Added XML (.xml, .xml.gz, .xml.bz2) to supported formats list
- ✅ **Convert Command**: Added all XML-specific options with descriptions
  - `--flatten-strategy` (conservative, moderate, aggressive)
  - `--array-handling` (expand, concatenate, json_string)  
  - `--namespace-handling` (preserve, strip, prefix)
  - `--preview-schema` (structure preview flag)
- ✅ **Examples**: Added XML conversion examples throughout help text

### Documentation Updates
- ✅ **README.md**: Updated features, examples, supported formats table, changelog
- ✅ **docs/index.md**: Added XML to format table, quick start, and version history
- ✅ **docs/converters/index.md**: Added XML converter card and examples
- ✅ **docs/reference/cli-reference.md**: Added XML options to command reference
- ✅ **docs/reference/output-formats.md**: Updated Parquet section for XML support
- ✅ **docs/USAGE.md**: Added XML conversion examples

### Implementation Details
- XML options properly pass from CLI to converter
- Maintains backward compatibility with existing commands
- All documentation now synchronized with v0.3.0 capabilities

## Testing
- ✅ `pyforge --help` shows XML capabilities
- ✅ `pyforge convert --help` includes XML options and examples  
- ✅ `pyforge formats` displays XML in supported formats table
- ✅ All XML CLI options function correctly

## Closes
Fixes #8

## Documentation Impact
Users can now discover and use XML converter features through:
- Complete CLI help system
- Updated README and documentation site
- Comprehensive examples and usage patterns